### PR TITLE
collect old and new genes

### DIFF
--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -1,4 +1,4 @@
-function draftModel=getModelFromHomology(models,blastStructure,...
+function [draftModel, hitGenes]=getModelFromHomology(models,blastStructure,...
     getModelFor,preferredOrder,strictness,onlyGenesInModels,maxE,...
     minLen,minIde,mapNewGenesToOld)
 % getModelFromHomology
@@ -47,6 +47,7 @@ function draftModel=getModelFromHomology(models,blastStructure,...
 %                     (opt, default true)
 %
 %   draftModel        a model structure for the new organism
+%   hitGenes          collect the old and new genes
 %
 %   The models in the 'models' structure should have named the metabolites
 %   in the same manner, have their reversible reactions in the same
@@ -67,6 +68,9 @@ function draftModel=getModelFromHomology(models,blastStructure,...
 %
 %   Simonas Marcisauskas, 2018-08-09
 %
+
+hitGenes.oldGenes = [];  % collect the old genes from the template model (organism)
+hitGenes.newGenes = [];  % collect the new genes of the draft model (target organism)
 
 if nargin<4
     preferredOrder=[];
@@ -438,6 +442,9 @@ for i=1:numel(models)
             mapIndex=find(ismember(allGenes{i+1},geneName));
             
             if ~isempty(mapIndex)
+                % add the old genes
+                hitGenes.oldGenes = [hitGenes.oldGenes, {geneName}];
+                
                 %Get the new genes for that gene
                 a=find(finalMappings{i}(:,mapIndex));
                 
@@ -455,6 +462,10 @@ for i=1:numel(models)
                 for l=2:numel(b)
                     repString=[repString ') or (' fullGeneList{b(l)}];
                 end
+                
+                % add the new mathed genes
+                hitGenes.newGenes = [hitGenes.newGenes, {repString}];
+                
                 %Use regexprep instead of strrep to prevent partial matches
                 models{useOrderIndexes(i)}.grRules{j}=regexprep(models{useOrderIndexes(i)}.grRules{j},['(^|\s|\()' geneName{1} '($|\s|\))'],['$1' repString '$2']);
             else


### PR DESCRIPTION
In some cases, multiple genes from the target organism will match with one old gene from the template organism and all of those genes will be included in the template model. If two proteomes from different assemblies of the target organism are used to extract a draft model and we want to compare which proteome extracts the most information from the template model, instead of looking at the new genes, we should look at the number of old genes, since there may be lots of duplications in the new genes.

### Main improvements in this PR:
feat:
- add a feature in `getModelFromHomology.m` to collect both old and new genes

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR (Refer to the message on Oct 11 2019)

*Note: replace [ ] with [X] to check the box. PLEASE DELETE THIS LINE*
